### PR TITLE
add "files" to package.json for distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "source": "./src/index.ts",
+  "files": [
+    "dist/**"
+  ],
   "scripts": {
     "build": "tsc && tsc -p tsconfig-cjs.json",
     "dry-run": "npm publish --dry-run",


### PR DESCRIPTION
Currently this package cant be used because the `.gitignore` excludes `/dist` from the package on release. [npm docs](https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package)

this change adds `"files"` field to `package.json` which takes precedence over `.gitignore` or `.npmignore` etc.