### PR TITLE
feat(api): make tracerName optional with default 'bullmq'

### DIFF
--- a/src/bullMQOtel.ts
+++ b/src/bullMQOtel.ts
@@ -91,7 +91,7 @@ export class BullMQOtel implements Telemetry<OtelContext> {
   tracer: BullMQOtelTracer;
   contextManager: BullMQOTelContextManager;
 
-  constructor(tracerName: string, version?: string) {
+  constructor(tracerName = 'bullmq', version?: string) {
     this.tracer = new BullMQOtelTracer(trace.getTracer(tracerName, version));
     this.contextManager = new BullMQOTelContextManager();
   }


### PR DESCRIPTION
## Summary
- Make `tracerName` parameter optional in `BullMQOtel` constructor, defaulting to `'bullmq'`

## Motivation
The conventional pattern for OTel tracers is to use the library name as the default tracer name (similar to how `@opentelemetry/instrumentation-http` uses its own name). This simplifies usage - consumers don't need to specify a tracer name unless they have a specific reason to override it.

### Before
```typescript
const telemetry = new BullMQOtel("my-tracer"); // tracerName required
```

### After
```typescript
const telemetry = new BullMQOtel(); // uses 'bullmq' as default
const telemetry = new BullMQOtel("custom-name"); // still works
```

## Test plan
- [x] Verify TypeScript compiles with the change
- [x] Verify default value is applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)